### PR TITLE
Atualizado cálculo de fator de vencimento

### DIFF
--- a/src/PhpBoletoZf2/Lib/Util.php
+++ b/src/PhpBoletoZf2/Lib/Util.php
@@ -121,7 +121,14 @@ abstract class Util
             $ano = $data[2];
             $mes = $data[1];
             $dia = $data[0];
-            return(abs((self::dataParaDias("1997", "10", "07")) - (self::dataParaDias($ano, $mes, $dia))));
+
+            $fator = abs((self::dataParaDias("1997", "10", "07")) - (self::dataParaDias($ano, $mes, $dia)));
+
+            if ($fator > 9999) {
+                $fator = ($fator % 10000) + 1000;
+            }
+
+            return $fator;
         } else {
             return "0000";
         }


### PR DESCRIPTION
Depois de 9999 o número de dígitos na linha digitável aumenta e por causa disso quebra 

A Febrabam definiu uma regra do que fazer nesses casos:

https://documentacao.senior.com.br/noticias/2025/2025-01-29-fator-vencimento-febraban.htm